### PR TITLE
[SHOULD IMPROVE] Invalidate token deleting it when the user want to logout from the system.

### DIFF
--- a/Visualizesse.API/Program.cs
+++ b/Visualizesse.API/Program.cs
@@ -28,6 +28,7 @@ builder.Services.AddScoped<ITransactionRepository, TransactionRepository>();
 builder.Services.AddScoped<ICategoryRepository, CategoryRepository>();
 builder.Services.AddScoped<ISubcategoryRepository, SubcategoryRepository>();
 builder.Services.AddScoped<IWalletRepository, WalletRepository>();
+builder.Services.AddScoped<ISessionRepository, SessionRepository>();
 builder.Services.AddScoped<IAuthService, AuthService>();
 
 builder.Services.AddTransient<UserService>();

--- a/Visualizesse.Domain/Services/IAuthService.cs
+++ b/Visualizesse.Domain/Services/IAuthService.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Visualizesse.Domain.Entities;
 
 namespace Visualizesse.Domain.Services;
@@ -7,4 +8,5 @@ public interface IAuthService
     string GenerateJWTToken(User user);
     string ComputeSHA256Hash(string password);
     bool CompareComputedSHA256Hash(string password, string hashedPassword);
+    IEnumerable<Claim> ReadJWTToken(string token);
 }

--- a/Visualizesse.Infrastructure/Auth/AuthService.cs
+++ b/Visualizesse.Infrastructure/Auth/AuthService.cs
@@ -57,6 +57,14 @@ public class AuthService(IConfiguration configuration) : IAuthService
         }
     }
 
+    public IEnumerable<Claim> ReadJWTToken(string token)
+    {
+        var tokenHandler = new JwtSecurityTokenHandler();
+        var jwtToken = tokenHandler.ReadJwtToken(token);
+
+        return jwtToken.Claims;
+    }
+
     public bool CompareComputedSHA256Hash(string password, string hashedPassword)
     {
         return hashedPassword == ComputeSHA256Hash(password);

--- a/Visualizesse.Infrastructure/DatabaseContext.cs
+++ b/Visualizesse.Infrastructure/DatabaseContext.cs
@@ -16,6 +16,7 @@ public class DatabaseContext : DbContext
     public DbSet<Category> Category { get; set; }
     public DbSet<Subcategory> Subcategory { get; set; }
     public DbSet<Wallet> Wallet { get; set; }
+    public DbSet<Session> Session { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/Visualizesse.Infrastructure/Migrations/DatabaseContextModelSnapshot.cs
+++ b/Visualizesse.Infrastructure/Migrations/DatabaseContextModelSnapshot.cs
@@ -40,6 +40,28 @@ namespace Visualizesse.Infrastructure.Migrations
                     b.ToTable("Category");
                 });
 
+            modelBuilder.Entity("Visualizesse.Domain.Entities.Session", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("Token")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<Guid>("UserId")
+                        .HasColumnType("uuid");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("Session");
+                });
+
             modelBuilder.Entity("Visualizesse.Domain.Entities.Subcategory", b =>
                 {
                     b.Property<int>("Id")
@@ -162,6 +184,17 @@ namespace Visualizesse.Infrastructure.Migrations
                     b.HasIndex("UserId");
 
                     b.ToTable("Wallet");
+                });
+
+            modelBuilder.Entity("Visualizesse.Domain.Entities.Session", b =>
+                {
+                    b.HasOne("Visualizesse.Domain.Entities.User", "User")
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("User");
                 });
 
             modelBuilder.Entity("Visualizesse.Domain.Entities.Subcategory", b =>


### PR DESCRIPTION
#9

I created a table called `Session` and related to `User` table.

![image](https://github.com/vagnerwentz/visualizesse/assets/26815672/b7611ab4-1910-4c5a-9d7a-db0a24c241a8)

First of all, when are developing sign-in and sign-out features the easy way it is just to delete the token in the session storage from browser. But we should invalidate the token at server side, like about the expiresAt and deleting the token, because the `expiresAt` it just will invalidate the token liked a time.

- [x] Create the sign-out route.
- [x] Create a new table to store the token.

Test 1
- [x] You must log in to the platform.
- [x] You must make a request that the token is necessary.
- [X] You must make a request to invalidate the token.
- [ ] You must make a request again using the first token created.[1]

[1] I am thinking of how I could validate the token if it is valid even I deleted it using the sign-out route and thinking it the token is still valid about `expiresAt` maybe we should re-write the `RequireAuthorization` .NET method or should create a middleware?